### PR TITLE
API 19 Crash FIX: Okhttp library version changed to 3.12.12

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,6 @@ task clean(type: Delete) {
 }
 
 ext {
-    sdkVersionCode = 21
-    sdkVersionName = "0.5.0"
+    sdkVersionCode = 22
+    sdkVersionName = "0.5.1"
 }

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -79,5 +79,5 @@ dependencies {
     implementation "com.squareup.retrofit2:retrofit:2.9.0"
     implementation "com.squareup.retrofit2:converter-gson:2.9.0"
     implementation "com.squareup.retrofit2:retrofit-mock:2.9.0"
-    implementation "com.squareup.okhttp3:logging-interceptor:4.9.3"
+    implementation 'com.squareup.okhttp3:logging-interceptor:3.12.12'
 }

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -79,5 +79,5 @@ dependencies {
     implementation "com.squareup.retrofit2:retrofit:2.9.0"
     implementation "com.squareup.retrofit2:converter-gson:2.9.0"
     implementation "com.squareup.retrofit2:retrofit-mock:2.9.0"
-    implementation "com.squareup.okhttp3:logging-interceptor:5.0.0-alpha.2"
+    implementation "com.squareup.okhttp3:logging-interceptor:4.9.3"
 }

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -79,5 +79,6 @@ dependencies {
     implementation "com.squareup.retrofit2:retrofit:2.9.0"
     implementation "com.squareup.retrofit2:converter-gson:2.9.0"
     implementation "com.squareup.retrofit2:retrofit-mock:2.9.0"
+    implementation('com.squareup.okhttp3:okhttp') { version { strictly '3.12.12'  } }
     implementation 'com.squareup.okhttp3:logging-interceptor:3.12.12'
 }


### PR DESCRIPTION
okhttp library version is 5.0.0-alpha2 which is unstable. As per the official docs of Okhttp, the current stable version is 4.9.3.
