### PR TITLE
Retrofit library changed to 2.6.0(API 19)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,6 @@ task clean(type: Delete) {
 }
 
 ext {
-    sdkVersionCode = 22
-    sdkVersionName = "0.5.1"
+    sdkVersionCode = 23
+    sdkVersionName = "0.5.2"
 }

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -76,9 +76,9 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-viewmodel-savedstate:2.3.1"
     implementation 'androidx.paging:paging-runtime-ktx:3.0.1'
     // retrofit
-    implementation "com.squareup.retrofit2:retrofit:2.9.0"
-    implementation "com.squareup.retrofit2:converter-gson:2.9.0"
-    implementation "com.squareup.retrofit2:retrofit-mock:2.9.0"
+    implementation "com.squareup.retrofit2:retrofit:2.6.0"
+    implementation "com.squareup.retrofit2:converter-gson:2.6.0"
+    implementation "com.squareup.retrofit2:retrofit-mock:2.6.0"
     implementation('com.squareup.okhttp3:okhttp') { version { strictly '3.12.12'  } }
     implementation 'com.squareup.okhttp3:logging-interceptor:3.12.12'
 }


### PR DESCRIPTION
Fixes # API 19 compatible latest stable retrofit library version: 2.6.0