### PR TITLE
Allow developers to provide custom Stipop.json file

### DIFF
--- a/sdk/src/main/java/io/stipop/Config.kt
+++ b/sdk/src/main/java/io/stipop/Config.kt
@@ -86,8 +86,8 @@ internal object Config {
     private var previewFavoritesOffIconName = ""
     private var previewCloseIconName = ""
 
-    internal fun configure(context: Context, callback: ((isSuccess: Boolean) -> Unit)) {
-        val jsonString = getJsonDataFromAsset(context) ?: return
+    internal fun configure(context: Context, configFileName: String, callback: ((isSuccess: Boolean) -> Unit)) {
+        val jsonString = getJsonDataFromAsset(configFileName, context) ?: return
         try {
             val json = JSONObject(jsonString)
             stipopConfigData = Gson().fromJson(jsonString, StipopConfigData::class.java)
@@ -104,10 +104,10 @@ internal object Config {
         }
     }
 
-    private fun getJsonDataFromAsset(context: Context): String? {
+    private fun getJsonDataFromAsset(fileName: String, context: Context): String? {
         val jsonString: String
         try {
-            jsonString = context.assets.open(Constants.KEY.ASSET_NAME).bufferedReader()
+            jsonString = context.assets.open(fileName).bufferedReader()
                 .use { it.readText() }
         } catch (ioException: IOException) {
             ioException.printStackTrace()

--- a/sdk/src/main/java/io/stipop/Stipop.kt
+++ b/sdk/src/main/java/io/stipop/Stipop.kt
@@ -86,11 +86,16 @@ class Stipop(
             SAuthManager.setAccessToken(accessToken)
         }
 
-        fun configure(context: Context, sAuthDelegate: SAuthDelegate? = null, callback: ((isSuccess: Boolean) -> Unit)? = null) {
+        fun configure(
+            context: Context,
+            sAuthDelegate: SAuthDelegate? = null,
+            configFileName: String = Constants.KEY.ASSET_NAME,
+            callback: ((isSuccess: Boolean) -> Unit)? = null,
+        ) {
             sAuthDelegate?.let {
                 this.sAuthDelegate = it
             }
-            Config.configure(context, callback = { result ->
+            Config.configure(context, configFileName, callback = { result ->
                 mainScope.launch {
                     configRepository.isConfigured = result
                     callback?.let { callback -> callback(result) }
@@ -115,7 +120,7 @@ class Stipop(
             if (!configRepository.isConfigured) {
                 if(canRetryIfConnectFailed){
                     Log.w("STIPOP-SDK", "Stipop SDK not connected. Because 'canRetryIfConnectFailed' is True, SDK calls 'configure(context)' automatically just once.")
-                    configure(activity, callback = {
+                    configure(activity, null, Constants.KEY.ASSET_NAME, callback = {
                         if(it) connect(activity, userId, delegate, stipopButton, stickerPickerFragment, locale, taskCallBack)
                         canRetryIfConnectFailed = false
                     })


### PR DESCRIPTION
Example case: Application has 2 environments with different security levels: PRODUCTION and DEV stages with different stipop applications bound to each. Developer can switch enviroment in runtime, so they need to provide an appropriate config file to Stipop.configure(..)