### PR TITLE
Fix resources overlap

### DIFF
--- a/sdk/src/main/res/values/strings.xml
+++ b/sdk/src/main/res/values/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <public name="sticker_cannot_download_msg" type="string" />
     <string name="downloaded">Download Complete</string>
     <string name="download">Download</string>
     <string name="search">Search</string>


### PR DESCRIPTION
Mark one string as public. Hopefully this should mark all other as 'private', preventing merging resources with same names for apps using this sdk.


We have a problem:

1. We have string "Downloaded" with text1
2. You have string "Downloaded" with text2

In our app, in place not about stickers it displays text2


First solution is try to make library resources private, hope after that build tool with ignore them when merging resources

Second is to add "stipop_" prefix to all resources